### PR TITLE
feature/run-container-with-current-user: adapt Docker config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,25 +19,25 @@ RUN apt update && \
 
 
 # Create a non-root user
-ARG USERNAME=user
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-RUN groupadd --gid $USER_GID $USERNAME && \
-    useradd --uid $USER_UID --gid $USER_GID --create-home --shell /bin/bash $USERNAME
+ARG USER
+ARG USER_ID
+ARG GROUP_ID
+RUN groupadd --gid $GROUP_ID $USER && \
+    useradd --uid $USER_ID --gid $GROUP_ID --create-home --shell /bin/bash $USER
 
 # Set up .bashrc
 RUN \
     # Add terminal coloring for the new user
-    echo 'PS1="(container) ${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "' >> /home/${USERNAME}/.bashrc && \
+    echo 'PS1="(container) ${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ "' >> /home/$USER/.bashrc && \
     # Disable "EasyInstallDeprecationWarning: easy_install command is deprecated"
-    echo 'PYTHONWARNINGS="ignore:easy_install command is deprecated,ignore:setup.py install is deprecated"' >> /home/$USERNAME/.bashrc  && \
-    echo 'export PYTHONWARNINGS' >> /home/$USERNAME/.bashrc && \
+    echo 'PYTHONWARNINGS="ignore:easy_install command is deprecated,ignore:setup.py install is deprecated"' >> /home/$USER/.bashrc  && \
+    echo 'export PYTHONWARNINGS' >> /home/$USER/.bashrc && \
     # Source ROS 2 setup
-    echo "source /opt/ros/jazzy/setup.bash" >> /home/$USERNAME/.bashrc && \
-    echo "source install/setup.bash" >> /home/$USERNAME/.bashrc
+    echo "source /opt/ros/jazzy/setup.bash" >> /home/$USER/.bashrc && \
+    echo "source install/setup.bash" >> /home/$USER/.bashrc
 
 # Switch to the non-root user
-USER $USERNAME
+USER $USER
 
 # Set entry point
 CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -21,8 +21,12 @@ and the [CMakeLists.txt](src/app/CMakeLists.txt)
 ## Get up and running
 ```bash
 git clone git@github.com:abaeyens/ros2-integration-testing-examples.git
+cd ros2-integration-testing-examples
+
+echo -e USER_ID=$(id -u $USER)\\nGROUP_ID=$(id -g $USER) >> .env
 docker compose build --pull
 docker compose run --rm app bash
+
 colcon build
 source install/setup.bash
 colcon test --event-handlers console_direct+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        USER: ${USER}
+        USER_ID: ${USER_ID}
+        GROUP_ID: ${GROUP_ID}
     command: bash -c "source /opt/ros/jazzy/setup.bash && exec bash"
     working_dir: ${PWD}
     volumes:
@@ -10,7 +14,7 @@ services:
       - /dev:/dev
       - /tmp:/tmp
       - /var/log/journal:/var/log/journal
-      - ${XAUTHORITY}:/home/user/.Xauthority:ro
+      - ${XAUTHORITY:-/home/${USER}/.Xauthority}:/home/${USER}/.Xauthority:ro
     environment:
       # Graphics
       - DISPLAY=${DISPLAY}


### PR DESCRIPTION
Let the Docker container run with the current user such that both user name, user ID and the user's group ID match between host and container, avoiding permission mismatch issues between host and container.

Previously the Docker setup didn't work well when running it from a host user that didn't have ID 1000.
